### PR TITLE
Use Source.scan() to maintain a materialized view of Source and Target objects

### DIFF
--- a/core/src/main/scala/reconciler/Reconciler.scala
+++ b/core/src/main/scala/reconciler/Reconciler.scala
@@ -123,10 +123,6 @@ abstract class Reconciler[S <: CustomResource[_, _]: Typeable, T <: ObjectResour
   case class CacheEntryKey(name: String, namespace: String, kind: String)
   case class Cache(events: List[Event], cache: Map[CacheEntryKey, CacheEntry])
 
-  def keyer(o: ObjectResource): String = {
-    s"${o.metadata.namespace}/${o.kind}/${o.metadata.name}"
-  }
-
   def watchSourceRaw(implicit context: RequestContext,
                      sourceFormat: Format[S],
                      sourceListFormat: Format[ListResource[S]],

--- a/core/src/main/scala/reconciler/Reconciler.scala
+++ b/core/src/main/scala/reconciler/Reconciler.scala
@@ -178,34 +178,6 @@ abstract class Reconciler[S <: CustomResource[_, _]: Typeable, T <: ObjectResour
 
   }
 
-  def watchSourceRaw(implicit context: RequestContext,
-                     sourceFormat: Format[S],
-                     sourceListFormat: Format[ListResource[S]],
-                     sourceResourceDefinition: ResourceDefinition[S],
-                     sourceListResourceDefinition: ResourceDefinition[ListResource[S]],
-                     ec: ExecutionContext): Future[akka.stream.scaladsl.Source[WatchEvent[S], NotUsed]] = {
-    context.list[ListResource[S]].map { l =>
-      val initialSource = Source(l.items.map(l => WatchEvent(EventType.MODIFIED, l)))
-      val watchedSource = context.watchAllContinuously[S](Some(l.resourceVersion))
-
-      initialSource.concat(watchedSource)
-    }
-  }
-
-  def watchTargetRaw(implicit context: RequestContext,
-                     targetFormat: Format[T],
-                     targetListFormat: Format[ListResource[T]],
-                     targetResourceDefinition: ResourceDefinition[T],
-                     targetListResourceDefinition: ResourceDefinition[ListResource[T]],
-                     ec: ExecutionContext): Future[akka.stream.scaladsl.Source[WatchEvent[T], NotUsed]] = {
-    context.list[ListResource[T]].map { l =>
-      val initialSource = Source(l.items.map(l => WatchEvent(EventType.MODIFIED, l)))
-      val watchedSource = context.watchAllContinuously[T](Some(l.resourceVersion))
-
-      initialSource.concat(watchedSource)
-    }
-  }
-
   def scanner(acc: Cache, x: WatchEvent[_ >: T with S <: ObjectResource]): Cache = {
     val `WatchEvent[S]` = TypeCase[WatchEvent[S]]
     val `WatchEvent[T]` = TypeCase[WatchEvent[T]]

--- a/core/src/main/scala/reconciler/Reconciler.scala
+++ b/core/src/main/scala/reconciler/Reconciler.scala
@@ -192,8 +192,12 @@ abstract class Reconciler[S <: CustomResource[_, _]: Typeable, T <: ObjectResour
 
             acc.cache.get(sourceKey) match {
               case Some(s) =>
-                val cacheEntry = CacheEntry(s.s, List(we._object))
-                Cache(List(Modified(s.s, List(we._object))), acc.cache + (sourceKey -> cacheEntry))
+                val cacheEntry = we._type match {
+                  case EventType.DELETED =>
+                    CacheEntry(s.s, List.empty[T])
+                  case _ => CacheEntry(s.s, List(we._object))
+                }
+                Cache(List(Modified(s.s, cacheEntry.ts)), acc.cache + (sourceKey -> cacheEntry))
               case None =>
                 acc
             }

--- a/core/src/main/scala/reconciler/Reconciler.scala
+++ b/core/src/main/scala/reconciler/Reconciler.scala
@@ -226,7 +226,7 @@ abstract class Reconciler[S <: CustomResource[_, _]: Typeable, T <: ObjectResour
       } yield
         Source
           .combine(resourceState.source, resourceState.target)(Merge(_))
-          .scan(Cache(List.empty, resourceState.state))(scanner)
+          .scan(Cache(resourceState.state.values.toList.map(ce => Modified(ce.s, ce.ts)), resourceState.state))(scanner)
           .map(_.events)
     )
   }

--- a/core/src/main/scala/reconciler/Reconciler.scala
+++ b/core/src/main/scala/reconciler/Reconciler.scala
@@ -9,7 +9,7 @@ import akka.stream.scaladsl.{ Flow, GraphDSL, Merge, Partition, RunnableGraph, S
 import cr4s.interpreter._
 import play.api.libs.json.Format
 import scala.concurrent.{ ExecutionContext, Future }
-import shapeless.{ HList, LabelledGeneric, TypeCase, Typeable }
+import shapeless.{ HList, LabelledGeneric, Typeable, TypeCase }
 import skuber.{
   CustomResource,
   HasStatusSubresource,
@@ -119,9 +119,64 @@ abstract class Reconciler[S <: CustomResource[_, _]: Typeable, T <: ObjectResour
   }
   // scalastyle:on
 
-  case class CacheEntry(s: Option[Source], ts: List[Target])
+  case class CacheEntry(s: Source, ts: List[Target])
   case class CacheEntryKey(name: String, namespace: String, kind: String)
   case class Cache(events: List[Event], cache: Map[CacheEntryKey, CacheEntry])
+
+  case class Resource[O <: ObjectResource](watch: akka.stream.scaladsl.Source[WatchEvent[O], _], list: List[O])
+  case class ResourcesState(source: akka.stream.scaladsl.Source[WatchEvent[S], _],
+                            target: akka.stream.scaladsl.Source[WatchEvent[T], _],
+                            state: Map[CacheEntryKey, CacheEntry])
+
+  def buildResource[O <: ObjectResource](implicit context: RequestContext,
+                                         format: Format[O],
+                                         listFormat: Format[ListResource[O]],
+                                         resourceDefinition: ResourceDefinition[O],
+                                         ec: ExecutionContext): Future[Resource[O]] = {
+    context.list[ListResource[O]]().map { l =>
+      Resource[O](
+        context.watchAllContinuously[O](Some(l.resourceVersion)),
+        l.items
+      )
+    }
+  }
+
+  def buildState(sources: List[S], target: List[T]): Map[CacheEntryKey, CacheEntry] = {
+    val initKeys = sources.foldLeft(Map.empty[CacheEntryKey, CacheEntry]) {
+      case (acc, s) =>
+        val key = CacheEntryKey(name = s.name, namespace = s.namespace, kind = s.kind)
+        acc + (key -> CacheEntry(s, List.empty))
+    }
+
+    target.foldLeft(initKeys) {
+      case (acc, t) =>
+        val owner = t.metadata.ownerReferences.head
+        val sourceKey = CacheEntryKey(name = owner.name, namespace = t.namespace, kind = owner.kind)
+
+        acc.get(sourceKey).fold(acc)(s => acc + (sourceKey -> s.copy(ts = t :: s.ts)))
+    }
+  }
+
+  def buildResourcesState(implicit context: RequestContext,
+                          sourceFormat: Format[S],
+                          sourceListFormat: Format[ListResource[S]],
+                          sourceResourceDefinition: ResourceDefinition[S],
+                          targetFormat: Format[T],
+                          targetListFormat: Format[ListResource[T]],
+                          targetResourceDefinition: ResourceDefinition[T],
+                          ec: ExecutionContext): Future[ResourcesState] = {
+
+    for {
+      source <- buildResource[S]
+      target <- buildResource[T]
+    } yield
+      ResourcesState(
+        source.watch,
+        target.watch,
+        buildState(source.list, target.list)
+      )
+
+  }
 
   def watchSourceRaw(implicit context: RequestContext,
                      sourceFormat: Format[S],
@@ -151,6 +206,39 @@ abstract class Reconciler[S <: CustomResource[_, _]: Typeable, T <: ObjectResour
     }
   }
 
+  def scanner(acc: Cache, x: WatchEvent[_ >: T with S <: ObjectResource]): Cache = {
+    val `WatchEvent[S]` = TypeCase[WatchEvent[S]]
+    val `WatchEvent[T]` = TypeCase[WatchEvent[T]]
+
+    x match {
+      case `WatchEvent[S]`(we) =>
+        val key = CacheEntryKey(name = we._object.name, namespace = we._object.namespace, kind = we._object.kind)
+        val targets = acc.cache.get(key).fold(List.empty[T])(_.ts)
+        val cache = acc.cache + (key -> CacheEntry(we._object, targets))
+
+        we._type match {
+          case EventType.ADDED | EventType.MODIFIED => Cache(List(Modified(we._object, targets)), cache)
+          case EventType.DELETED                    => Cache(List(Deleted(we._object, targets)), cache - key)
+        }
+
+      case `WatchEvent[T]`(we) =>
+        val owner = we._object.metadata.ownerReferences.head
+        val sourceKey = CacheEntryKey(name = owner.name, namespace = we._object.namespace, kind = owner.kind)
+
+        acc.cache.get(sourceKey) match {
+          case Some(s) =>
+            val cacheEntry = we._type match {
+              case EventType.DELETED => CacheEntry(s.s, s.ts.filterNot(_.uid == we._object.uid))
+              case _                 => CacheEntry(s.s, List(we._object))
+            }
+            val cache = acc.cache + (sourceKey -> cacheEntry)
+            Cache(List(Modified(s.s, cacheEntry.ts)), cache)
+
+          case None => acc
+        }
+    }
+  }
+
   def merge(implicit context: RequestContext,
             sourceFormat: Format[S],
             sourceListFormat: Format[ListResource[S]],
@@ -158,47 +246,17 @@ abstract class Reconciler[S <: CustomResource[_, _]: Typeable, T <: ObjectResour
             targetFormat: Format[T],
             targetListFormat: Format[ListResource[T]],
             targetResourceDefinition: ResourceDefinition[T],
-            ec: ExecutionContext): akka.stream.scaladsl.Source[List[Event], NotUsed] = {
+            ec: ExecutionContext): akka.stream.scaladsl.Source[List[Event], Future[NotUsed]] = {
 
-    val sourceRaw = Source.fromFutureSource(watchSourceRaw)
-    val targetRaw = Source.fromFutureSource(watchTargetRaw)
-
-    val `WatchEvent[S]` = TypeCase[WatchEvent[S]]
-    val `WatchEvent[T]` = TypeCase[WatchEvent[T]]
-
-    Source
-      .combine(sourceRaw, targetRaw)(Merge(_))
-      .scan(Cache(List.empty, Map.empty)) { (acc, x) =>
-        x match {
-          case `WatchEvent[S]`(we) =>
-            val key = CacheEntryKey(name = we._object.name, namespace = we._object.namespace, kind = we._object.kind)
-            val targets = acc.cache.get(key).fold(List.empty[T])(_.ts)
-            val cache = acc.cache + (key -> CacheEntry(Some(we._object), targets))
-
-            we._type match {
-              case EventType.ADDED | EventType.MODIFIED => Cache(List(Modified(we._object, targets)), cache)
-              case EventType.DELETED                    => Cache(List(Deleted(we._object, targets)), cache)
-            }
-
-          case `WatchEvent[T]`(we) =>
-            // this assumes there's only one owner and they're in the same namespace
-            val owner = we._object.metadata.ownerReferences.head
-            val sourceKey = CacheEntryKey(name = owner.name, namespace = we._object.namespace, kind = owner.kind)
-
-            acc.cache.get(sourceKey) match {
-              case Some(s) =>
-                val cacheEntry = we._type match {
-                  case EventType.DELETED => CacheEntry(s.s, s.ts.filterNot(_.uid == we._object.uid))
-                  case _                 => CacheEntry(s.s, List(we._object))
-                }
-                val cache = acc.cache + (sourceKey -> cacheEntry)
-                s.s.fold(acc.copy(cache = cache))(source => Cache(List(Modified(source, cacheEntry.ts)), cache))
-
-              case None => acc.copy(cache = acc.cache + (sourceKey -> CacheEntry(None, List(we._object))))
-            }
-        }
-      }
-      .map(_.events)
+    Source.fromFutureSource(
+      for {
+        resourceState <- buildResourcesState
+      } yield
+        Source
+          .combine(resourceState.source, resourceState.target)(Merge(_))
+          .scan(Cache(List.empty, resourceState.state))(scanner)
+          .map(_.events)
+    )
   }
 
   def ownerReference[O <: ObjectResource](o: O): OwnerReference = {

--- a/example/src/main/scala/Main.scala
+++ b/example/src/main/scala/Main.scala
@@ -7,7 +7,6 @@ import cr4s.interpreter.SkuberInterpreter
 import skuber._
 import skuber.api.client.RequestLoggingContext
 import skuber.json.apps.format._
-import skuber.json.format._
 
 object Main extends App {
   implicit val system = ActorSystem()
@@ -19,11 +18,13 @@ object Main extends App {
   implicit val logger = Logging.getLogger(system, this)
 
   val fooDeploymentController = new FooDeploymentReconciler
-  val fooServiceController = new FooServiceReconciler
-
   val fdInterpreter = new SkuberInterpreter(k8s, fooDeploymentController)
-  val fsInterpreter = new SkuberInterpreter(k8s, fooServiceController)
-
-  fooServiceController.graph(fsInterpreter.flow(1), 1).run()
-  fooDeploymentController.graph(fdInterpreter.flow(1), 1).run()
+  fooDeploymentController.merge
+    .mapConcat(a => a.map(fooDeploymentController.reconciler))
+    .via(fdInterpreter.flow(1))
+    .runForeach(a => logger.info("{}", a))
+    .onComplete {
+      case scala.util.Success(_) =>
+      case scala.util.Failure(e) => logger.error("{}", e)
+    }
 }


### PR DESCRIPTION
This PR introduces `watchSourceRaw` and `watchTargetRaw` which unlike their un-raw counterparts do not process the incoming events. They're fed to a `scan()` which maintains a local cache.

/cc @pbarron @iainhull @doriordan